### PR TITLE
fix: ungrouped records

### DIFF
--- a/src/Aggregrid.js
+++ b/src/Aggregrid.js
@@ -742,7 +742,7 @@ Ext.define('Jarvus.aggregrid.Aggregrid', {
             row = rowMapper(record, rowsStore);
             column = columnMapper(record, columnsStore);
 
-            if (!row || !column) {
+            if (!row || !column || !groups[row.getId()] || !groups[row.getId()][column.getId()]) {
                 ungroupedRecords.push(record);
                 continue;
             }


### PR DESCRIPTION
This prevents an error that happens when an ungrouped record gets added to the store, before it's row or column exists, but after initial grouping/rendering.