### PR TITLE
[SCHOOL-52] Attempt to remedy Chrome border bug in large aggregrids

### DIFF
--- a/src/Aggregrid.js
+++ b/src/Aggregrid.js
@@ -995,6 +995,32 @@ Ext.define('Jarvus.aggregrid.Aggregrid', {
         }
 
         me.cellsPainted = true;
+        me.doLayoutPoke();
+    },
+
+    doLayoutPoke: function () {
+        // do some dumb bad user agent sniffing to poke chrome on windows and android
+        // to attempt to get it to properly render borders
+
+        var me = this,
+            ua = navigator.userAgent,
+            table,
+            opacityCache;
+
+        if (!ua.includes('Chrome')) {
+            // not chrome, abort
+            return;
+        }
+
+        if (ua.includes('Windows') || ua.includes('Linux')) {
+            // poke
+            table = me.el.down('.jarvus-aggregrid-data-table');
+            opacityCache = table.dom.style.opacity;
+            table.dom.style.opacity = 0.99;
+            setTimeout(function () {
+                table.dom.style.opacity = opacityCache;
+            }, 0);
+        }
     },
 
     doExpand: function(me, rowId) {


### PR DESCRIPTION
> https://jarvus.mydonedone.com/issuetracker/projects/80148/issues/34

- Sniff for user agent containing `'Chrome' AND ('Windows' OR 'Linux')`
- Grab table DOM and wiggle its opacity a little (should be visually imperceptible) to nudge the engine into drawing borders correctly

⚠️ Untested as yet